### PR TITLE
Update demos/tooltips.html

### DIFF
--- a/demos/tooltips.html
+++ b/demos/tooltips.html
@@ -100,7 +100,7 @@
 							tt.textContent = "(" + xVal + ", " + yVal + ")";
 
 							tt.style.left = Math.round(u.valToPos(xVal, 'x')) + "px";
-							tt.style.top = Math.round(u.valToPos(yVal, 'y')) + "px";
+							tt.style.top = Math.round(u.valToPos(yVal, s.scale)) + "px";
 						}
 					});
 				}


### PR DESCRIPTION
made tooltip demo usable even with custom scales - previously all tooltips used 'y' scale for tooltip top distance calculations, now using series specific scale